### PR TITLE
fix: revert beta-plan name changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | The name to give the Hyper Protect Crypto Service instance. Max length allowed is 30 chars. | `string` | n/a | yes |
 | <a name="input_number_of_crypto_units"></a> [number\_of\_crypto\_units](#input\_number\_of\_crypto\_units) | The number of operational crypto units for your service instance. | `number` | `2` | no |
 | <a name="input_number_of_failover_units"></a> [number\_of\_failover\_units](#input\_number\_of\_failover\_units) | The number of failover crypto units for your service instance. Default is 0 and cross-region high availability will not be enabled. | `number` | `0` | no |
-| <a name="input_plan"></a> [plan](#input\_plan) | The name of the service plan that you choose for your Hyper Protect Crypto Service instance. Beta-plan is for Hybrid HPCS. | `string` | `"standard"` | no |
+| <a name="input_plan"></a> [plan](#input\_plan) | The name of the service plan that you choose for your Hyper Protect Crypto Service instance. | `string` | `"standard"` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region where you want to deploy your instance. | `string` | n/a | yes |
 | <a name="input_resource_group_id"></a> [resource\_group\_id](#input\_resource\_group\_id) | The resource group name where the Hyper Protect Crypto Service instance will be created. | `string` | n/a | yes |
 | <a name="input_revocation_threshold"></a> [revocation\_threshold](#input\_revocation\_threshold) | The number of administrator signatures that is required to remove an administrator after you leave imprint mode. | `number` | `1` | no |

--- a/examples/hybrid-hpcs/main.tf
+++ b/examples/hybrid-hpcs/main.tf
@@ -14,7 +14,7 @@ module "hpcs_instance" {
   name                                            = "${var.prefix}-hpcs"
   region                                          = var.region
   tags                                            = var.resource_tags
-  plan                                            = "beta-plan"
+  plan                                            = "standard"
   resource_group_id                               = module.resource_group.resource_group_id
   auto_initialization_using_recovery_crypto_units = false
   hsm_connector_id                                = var.hsm_connector_id

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -82,7 +82,7 @@
     "plan": {
       "name": "plan",
       "type": "string",
-      "description": "The name of the service plan that you choose for your Hyper Protect Crypto Service instance. Beta-plan is for Hybrid HPCS.",
+      "description": "The name of the service plan that you choose for your Hyper Protect Crypto Service instance.",
       "default": "standard",
       "required": true,
       "source": [

--- a/variables.tf
+++ b/variables.tf
@@ -23,11 +23,11 @@ variable "name" {
 
 variable "plan" {
   type        = string
-  description = "The name of the service plan that you choose for your Hyper Protect Crypto Service instance. Beta-plan is for Hybrid HPCS."
+  description = "The name of the service plan that you choose for your Hyper Protect Crypto Service instance."
   default     = "standard"
   validation {
-    condition     = contains(["standard", "beta-plan"], var.plan)
-    error_message = "Only the standard and beta-plan is supported currently"
+    condition     = contains(["standard"], var.plan)
+    error_message = "Only the standard plan is supported currently"
   }
 }
 


### PR DESCRIPTION
### Description

Hybrid HPCS will be under standard plan for customers, beta-plan is for internal testing. It reverts back the plan name change.

### Types of changes in this PR

#### Changes that affect the core Terraform module or submodules
- [x] Bug fix
- [ ] New feature
- [ ] Dependency update

#### Changes that don't affect the core Terraform module or submodules
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other

#### Release required?
Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning).

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Changes plan name `beta-plan` to `standard`.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
