### PR TITLE
feat: add timeouts for create/update/delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_admins"></a> [admins](#input\_admins) | A list of administrators for the instance crypto units. See [instructions](https://github.com/terraform-ibm-modules/terraform-ibm-hpcs#before-you-begin) to create administrator signature keys. You can set up to 8 administrators. Required if auto\_initialization\_using\_recovery\_crypto\_units set to true. | <pre>list(object({<br>    name = string # max length: 30 chars<br>    key  = string # the absolute path and the file name of the signature key file if key files are created using TKE CLI and are not using a third-party signing service<br>    # if you are using a signing service, the key name is appended to a URI that will be sent to the signing service<br>    token = string # sensitive: the administrator password/token to authorize and access the corresponding signature key file<br>  }))</pre> | `[]` | no |
 | <a name="input_auto_initialization_using_recovery_crypto_units"></a> [auto\_initialization\_using\_recovery\_crypto\_units](#input\_auto\_initialization\_using\_recovery\_crypto\_units) | Set to true if auto initialization using recovery crypto units is required. | `bool` | `true` | no |
+| <a name="input_create_timeout"></a> [create\_timeout](#input\_create\_timeout) | Create timeout value of the HPCS instance. | `string` | `"120m"` | no |
+| <a name="input_delete_timeout"></a> [delete\_timeout](#input\_delete\_timeout) | Delete timeout value of the HPCS instance. | `string` | `"120m"` | no |
 | <a name="input_hsm_connector_id"></a> [hsm\_connector\_id](#input\_hsm\_connector\_id) | The HSM connector ID provided by IBM required for Hybrid HPCS. Available to selected customers only. | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name to give the Hyper Protect Crypto Service instance. Max length allowed is 30 chars. | `string` | n/a | yes |
 | <a name="input_number_of_crypto_units"></a> [number\_of\_crypto\_units](#input\_number\_of\_crypto\_units) | The number of operational crypto units for your service instance. | `number` | `2` | no |
@@ -186,6 +188,7 @@ No modules.
 | <a name="input_signature_server_url"></a> [signature\_server\_url](#input\_signature\_server\_url) | The URL and port number of the signing service. Required if auto\_initialization\_using\_recovery\_crypto\_units set to true and using a third-party signing service to provide administrator signature keys. Only used if auto\_initialization\_using\_recovery\_crypto\_units is true | `string` | `null` | no |
 | <a name="input_signature_threshold"></a> [signature\_threshold](#input\_signature\_threshold) | The number of administrator signatures that is required to execute administrative commands. Required if auto\_initialization\_using\_recovery\_crypto\_units set to true. | `number` | `1` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Optional list of resource tags to apply to the HPCS instance. | `list(string)` | `[]` | no |
+| <a name="input_update_timeout"></a> [update\_timeout](#input\_update\_timeout) | Update timeout value of the HPCS instance. | `string` | `"120m"` | no |
 
 ### Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,12 @@ resource "ibm_hpcs" "hpcs_instance" {
       token = admins.value["token"]
     }
   }
+
+  timeouts {
+    create = var.create_timeout
+    update = var.update_timeout
+    delete = var.delete_timeout
+  }
 }
 
 resource "ibm_resource_instance" "base_hpcs_instance" {
@@ -54,5 +60,11 @@ resource "ibm_resource_instance" "base_hpcs_instance" {
     byohsm          = (var.hsm_connector_id != null) ? true : null # true for Hybrid-HPCS
     hsm_connector   = (var.hsm_connector_id != null) ? var.hsm_connector_id : null
     allowed_network = var.service_endpoints
+  }
+
+  timeouts {
+    create = var.create_timeout
+    update = var.update_timeout
+    delete = var.delete_timeout
   }
 }

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -26,6 +26,26 @@
         "line": 34
       }
     },
+    "create_timeout": {
+      "name": "create_timeout",
+      "type": "string",
+      "description": "Create timeout value of the HPCS instance.",
+      "default": "120m",
+      "pos": {
+        "filename": "variables.tf",
+        "line": 121
+      }
+    },
+    "delete_timeout": {
+      "name": "delete_timeout",
+      "type": "string",
+      "description": "Delete timeout value of the HPCS instance.",
+      "default": "120m",
+      "pos": {
+        "filename": "variables.tf",
+        "line": 133
+      }
+    },
     "hsm_connector_id": {
       "name": "hsm_connector_id",
       "type": "string",
@@ -204,6 +224,16 @@
       "elem": {
         "type": "TypeString"
       }
+    },
+    "update_timeout": {
+      "name": "update_timeout",
+      "type": "string",
+      "description": "Update timeout value of the HPCS instance.",
+      "default": "120m",
+      "pos": {
+        "filename": "variables.tf",
+        "line": 127
+      }
     }
   },
   "outputs": {
@@ -304,7 +334,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 42
+        "line": 48
       }
     }
   },

--- a/variables.tf
+++ b/variables.tf
@@ -117,4 +117,22 @@ variable "hsm_connector_id" {
   description = "The HSM connector ID provided by IBM required for Hybrid HPCS. Available to selected customers only."
   default     = null
 }
+
+variable "create_timeout" {
+  type        = string
+  description = "Create timeout value of the HPCS instance."
+  default     = "120m"
+}
+
+variable "update_timeout" {
+  type        = string
+  description = "Update timeout value of the HPCS instance."
+  default     = "120m"
+}
+
+variable "delete_timeout" {
+  type        = string
+  description = "Delete timeout value of the HPCS instance."
+  default     = "120m"
+}
 ##############################################################################


### PR DESCRIPTION
### Description

Increase the default timeout for create/update/delete the HPCS instance to 120m.

### Types of changes in this PR

#### Changes that affect the core Terraform module or submodules
- [ ] Bug fix
- [x] New feature
- [ ] Dependency update

#### Changes that don't affect the core Terraform module or submodules
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other

#### Release required?
Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning).

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Increase the default timeout for create/update/delete the HPCS instance to 120m.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
