### PR TITLE
fix: update readme

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-07-13T08:02:39Z",
+  "generated_at": "2023-09-01T13:15:27Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,7 +82,7 @@
         "hashed_secret": "b7789e80adceebbe078db3e927944143c93e3116",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 158,
+        "line_number": 160,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -90,7 +90,7 @@
         "hashed_secret": "379f23674341f122f9075538a32277b5efaa2f7d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 163,
+        "line_number": 165,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-09-01T13:15:27Z",
+  "generated_at": "2023-09-04T14:09:35Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,7 +82,7 @@
         "hashed_secret": "b7789e80adceebbe078db3e927944143c93e3116",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 160,
+        "line_number": 161,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -90,7 +90,7 @@
         "hashed_secret": "379f23674341f122f9075538a32277b5efaa2f7d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 165,
+        "line_number": 166,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-09-04T14:09:35Z",
+  "generated_at": "2023-09-07T10:12:57Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,7 +82,7 @@
         "hashed_secret": "b7789e80adceebbe078db3e927944143c93e3116",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 161,
+        "line_number": 162,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -90,7 +90,7 @@
         "hashed_secret": "379f23674341f122f9075538a32277b5efaa2f7d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 166,
+        "line_number": 167,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The next step after provisioning an HPCS instance is to [initialize](https://clo
 For more information, see [components and concepts](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-understand-concepts) of HPCS and [about service instance initialization](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-introduce-service) in the Cloud Docs.
 
 
+If you provision HPCS instance with `private-only` endpoint then you receive the `public` and `private` endpoints URL in the output. Only the private endpoint works. The public endpoint is just for reference and only valid if public-and-private endpoint is setup.
+
 ## Create Hyper Protect Crypto Services instance
 
 ### Usage to create the HPCS instance
@@ -42,7 +44,7 @@ module "hpcs" {
   source                                          = "git::https://github.com/terraform-ibm-modules/terraform-ibm-hpcs?ref=main"
   resource_group_id                               = "000fb3134f214c3a9017554db4510f70" # pragma: allowlist secret
   region                                          = "us-south"
-  service_name                                    = "my-hpcs-instance"
+  name                                            = "my-hpcs-instance"
   tags                                            = ["tag1","tag2"]
   plan                                            = "standard"
   auto_initialization_using_recovery_crypto_units = false
@@ -110,7 +112,7 @@ module "hpcs" {
   source                                          = "git::https://github.com/terraform-ibm-modules/terraform-ibm-hpcs?ref=main"
   resource_group_id                               = "000fb3134f214c3a9017554db4510f70" # pragma: allowlist secret
   region                                          = "us-south"
-  service_name                                    = "my-hpcs-instance"
+  name                                            = "my-hpcs-instance"
   tags                                            = ["tag1","tag2"]
   auto_initialization_using_recovery_crypto_units = true
   number_of_crypto_units                          = 3
@@ -148,7 +150,7 @@ module "hpcs" {
   source                                          = "git::https://github.com/terraform-ibm-modules/terraform-ibm-hpcs?ref=main"
   resource_group_id                               = "000fb3134f214c3a9017554db4510f70" # pragma: allowlist secret
   region                                          = "us-south"
-  service_name                                    = "my-hpcs-instance"
+  name                                            = "my-hpcs-instance"
   tags                                            = ["tag1","tag2"]
   auto_initialization_using_recovery_crypto_units = true
   number_of_crypto_units                          = 3

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ The next step after provisioning an HPCS instance is to [initialize](https://clo
 For more information, see [components and concepts](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-understand-concepts) of HPCS and [about service instance initialization](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-introduce-service) in the Cloud Docs.
 
 
-If you provision HPCS instance with `private-only` endpoint then you receive the `public` and `private` endpoints URL in the output. Only the private endpoint works. The public endpoint is just for reference and only valid if public-and-private endpoint is setup.
+If you provision an HPCS instance with a `private-only` endpoint, both `public` and `private` endpoints URLs are included in the output. The public endpoint can be referenced only if there is a need for a temporary switch to enable public endpoint otherwise you can disregard the public endpoint.
+
 
 ## Create Hyper Protect Crypto Services instance
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ The next step after provisioning an HPCS instance is to [initialize](https://clo
 For more information, see [components and concepts](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-understand-concepts) of HPCS and [about service instance initialization](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-introduce-service) in the Cloud Docs.
 
 
-If you provision an HPCS instance with a `private-only` endpoint, both `public` and `private` endpoints URLs are included in the output. The public endpoint can be referenced only if there is a need for a temporary switch to enable public endpoint otherwise you can disregard the public endpoint.
+If you provision an HPCS instance with a `private-only` endpoint, both public and private endpoints URLs are included in the output. You can ignore the public endpoint. It is included for convenience in case you need to switch to it temporarily. However, make sure that you switch back to the private endpoint as soon as possible.
+
 
 
 ## Create Hyper Protect Crypto Services instance


### PR DESCRIPTION
### Description

It updates readme regarding the public and private endpoint in output if instance is provisioned with private-only endpoint.

https://github.ibm.com/GoldenEye/issues/issues/5443

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

if instance is provisioned with `private-only` endpoints, then public and private endpoints url are available in output. The public endpoint is available for reference and only private endpoint works.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- When merging, use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
