### PR TITLE
test: update dir to generate keys by complete test

### DIFF
--- a/tests/other_test.go
+++ b/tests/other_test.go
@@ -3,6 +3,7 @@ package test
 
 import (
 	"log"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,6 +30,12 @@ func TestRunCompleteExample(t *testing.T) {
 	t.Parallel()
 
 	usernames := []string{"admin1"}
+
+	cwd, err1 := os.Getwd()
+	if err1 != nil {
+		log.Fatalf("Error getting current working directory: %v", err1)
+	}
+	sigDirectory = cwd + "/keys"
 
 	admins, err := CreateSigKeys(usernames, sigDirectory)
 	if !assert.Nilf(t, err, "Error creating sigkeys: %v", err) {


### PR DESCRIPTION
### Description

Update test because of cont test failure issue. Creates HPCS keys in separate dir for each test.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
