### PR TITLE
fix(deps): bump terraform IBM provider to 1.79.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ You need the following permissions to run this module.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.49.0, < 2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.79.0, < 2.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.4.0, < 3.0.0 |
 
 ### Modules

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -5,7 +5,7 @@ terraform {
     # module's version.tf (basic example), and 1 example that will always use the latest provider version (complete example).
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.49.0"
+      version = "1.79.0"
     }
   }
 }

--- a/examples/complete/version.tf
+++ b/examples/complete/version.tf
@@ -5,7 +5,7 @@ terraform {
     # module's version.tf (basic example), and 1 example that will always use the latest provider version (complete example).
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.49.0"
+      version = ">= 1.79.0"
     }
   }
 }

--- a/examples/fscloud/version.tf
+++ b/examples/fscloud/version.tf
@@ -5,7 +5,7 @@ terraform {
     # module's version.tf (basic example), and 1 example that will always use the latest provider version (complete example).
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.49.0"
+      version = ">= 1.79.0"
     }
   }
 }

--- a/examples/hybrid-hpcs/version.tf
+++ b/examples/hybrid-hpcs/version.tf
@@ -5,7 +5,7 @@ terraform {
     # module's version.tf (basic example), and 1 example that will always use the latest provider version (complete example).
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.49.0"
+      version = "1.79.0"
     }
   }
 }

--- a/version.tf
+++ b/version.tf
@@ -5,7 +5,7 @@ terraform {
     # Use "greater than or equal to" range in modules
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.49.0, < 2.0.0"
+      version = ">= 1.79.0, < 2.0.0"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
### Description

Pull in the fix for https://github.com/IBM-Cloud/terraform-provider-ibm/issues/6269

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
